### PR TITLE
Increase max line length to 100

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 88
+max-line-length = 120
 extend-ignore = E203, E704
 exclude =
     venv

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 120
+max-line-length = 100
 extend-ignore = E203, E704
 exclude =
     venv

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,7 +1,7 @@
 ---
 name: Super-Linter
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - main

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -77,12 +77,7 @@ WSGI_APPLICATION = "controlpanel.wsgi.application"
 
 # -- Database
 DB_HOST = os.environ.get("DB_HOST", "127.0.0.1")
-ENABLE_DB_SSL = (
-    str(
-        os.environ.get("ENABLE_DB_SSL", DB_HOST not in ["127.0.0.1", "localhost"])
-    ).lower()
-    == "true"
-)
+ENABLE_DB_SSL = str(os.environ.get("ENABLE_DB_SSL", DB_HOST not in ["127.0.0.1", "localhost"])).lower() == "true"
 DATABASES: dict = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -77,7 +77,10 @@ WSGI_APPLICATION = "controlpanel.wsgi.application"
 
 # -- Database
 DB_HOST = os.environ.get("DB_HOST", "127.0.0.1")
-ENABLE_DB_SSL = str(os.environ.get("ENABLE_DB_SSL", DB_HOST not in ["127.0.0.1", "localhost"])).lower() == "true"
+ENABLE_DB_SSL = (
+    str(os.environ.get("ENABLE_DB_SSL", DB_HOST not in ["127.0.0.1", "localhost"])).lower()
+    == "true"
+)
 DATABASES: dict = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-line-length = 88
+line-length = 120
 target-version = ["py311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-line-length = 120
+line-length = 100
 target-version = ["py311"]


### PR DESCRIPTION
Increases the **max** line length check in black and flake8 to 100. This is still recognised as acceptable by pep8, as in practice keeping to 79 (or even 88 which [black](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length) defaults to)  can be difficult and lead to some awkward formatting. Despite increasing the max limit, I still think the aim should be to keep to a _soft limit_ of around 88 when possible.
