### PR TITLE
👨‍💻 Updates to `Makefile` 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# The contents of this file are purely for local development
+# They are NOT sensitive and should not be used in production
+# Populate these values in a .env file in the root of the project and update them as necessary
+
+DB_USER=<located in contrib/docker-compose-postgres.yml>
+DB_PASSWORD=<located in contrib/docker-compose-postgres.yml>
+SECRET_KEY=<create-a-long-string>
+PGPASSWORD=<located in contrib/docker-compose-postgres.yml>

--- a/.env.local
+++ b/.env.local
@@ -1,7 +1,0 @@
-# The contents of this file are purely for local development
-# They are NOT sensitive and should not be used in production
-
-DB_USER=controlpanel
-DB_PASSWORD=controlpanel
-SECRET_KEY=this-is-a-local-development-key-not-an-actual-secret-key-cmon
-PGPASSWORD=controlpanel

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,7 @@
+# The contents of this file are purely for local development
+# They are NOT sensitive and should not be used in production
+
+DB_USER=controlpanel
+DB_PASSWORD=controlpanel
+SECRET_KEY=this-is-a-local-development-key-not-an-actual-secret-key-cmon
+PGPASSWORD=controlpanel

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
+#!make
+-include .env.local
+export
+
 build:
 	make build-static
 	make build-js
-
 
 build-static:
 	mkdir -p static/assets/fonts
@@ -10,7 +13,18 @@ build-static:
 	cp -R node_modules/govuk-frontend/govuk/assets/images/. static/assets/images
 	npm run css
 
-
 build-js:
 	mkdir -p static/assets/js
 	cp node_modules/govuk-frontend/govuk/all.js static/assets/js/govuk.js
+
+db-migrate:
+	python manage.py migrate
+
+db-connect:
+	psql --username=controlpanel --host=localhost --dbname=controlpanel
+
+db-drop:
+	python manage.py reset_db
+
+serve:
+	python manage.py runserver

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 #!make
--include .env.local
-export
 
 build:
 	make build-static

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,6 @@ build-js:
 db-migrate:
 	python manage.py migrate
 
-db-connect:
-	psql --username=controlpanel --host=localhost --dbname=controlpanel
-
 db-drop:
 	python manage.py reset_db
 

--- a/controlpanel/interfaces/web/templates/base.html
+++ b/controlpanel/interfaces/web/templates/base.html
@@ -2,7 +2,7 @@
 {% extends "govuk_frontend_django/base.html" %}
 {% load static govuk_frontend_django %}
 
-{% block title %}Data platform Control panel{% endblock title %}
+{% block title %}Data Platform Control Panel{% endblock title %}
 
 {% block head %}
     <link href="{% static 'app.css' %}" rel="stylesheet" type="text/css" />

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_extensions",
     # web frontend
     "govuk_frontend_django",
     "controlpanel.interfaces.web",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "sass": "^1.69.5"
   },
   "dependencies": {
-    "govuk-frontend": "^4.7.0"
+    "govuk-frontend": "4.7.0"
   }
 }

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,5 +3,5 @@ black==23.11.0
 django-stubs[compatible-mypy]==4.2.6
 flake8==6.1.0
 isort==5.12.0
-mypy==1.7.0
+mypy==1.6.0
 pre-commit==3.5.0


### PR DESCRIPTION
This PR does a number of things: 

- ⬇️ Downgrade `mypy` to resolve issues
- ✏️ Capitalise header
- ➕ Add `django_extensions`
- 👶 Create `.env.local`
- 👨‍💻 Add `db-*` commands to Makefile
- 📌 Pin `govuk-frontend`

Most importantly this edits the `Makefile` to add `db-*` commands. The inclusion of the following lines pulls variables from the `.env.local` command.  
```bash
-include .env.local
export
...
```
The addition of `django_extensions`  was needed to create the `make db-drop` command.

Additionally I've added the following which are self-explanatory:

```bash
db-migrate:
	python manage.py migrate

db-connect:
	psql --username=controlpanel --host=localhost --dbname=controlpanel

db-drop:
	python manage.py reset_db

serve:
	python manage.py runserver
```

The contents of the `.env.local` file are for development purposes only. 