### PR TITLE
🦝 Add `PYTHON_ISORT_CONFIG_FILE` to Super-Linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -38,4 +38,5 @@ jobs:
           LINTER_RULES_PATH: /
           PYTHON_BLACK_CONFIG_FILE: pyproject.toml
           PYTHON_FLAKE8_CONFIG_FILE: .flake8
+          PYTHON_ISORT_CONFIG_FILE: pyproject.toml
           PYTHON_MYPY_CONFIG_FILE: mypy.ini


### PR DESCRIPTION
This pull request points `ISORT` to `pyproject.toml` in Super-Linter

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>