### PR TITLE
🔥 Remove build on merge to `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 permissions: {}
 


### PR DESCRIPTION
This pull request removes the build workflow from merging to `main`

Signed-off-by: Jacob Woffenden <jacob@woffenden.io>