### PR TITLE
✨ Update cosign to use image digests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Sign
         id: sign
         run: |
-          cosign sign --yes ghcr.io/${{ github.repository_owner }}/data-platform-control-panel:${{ github.ref_name }}
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/data-platform-control-panel:${{ steps.push.outputs.digest }}
 
       - name: Verify
         id: verify
@@ -51,4 +51,4 @@ jobs:
           cosign verify \
           --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
           --certificate-identity=https://github.com/${{ github.repository_owner }}/data-platform-control-panel/.github/workflows/release.yml@refs/tags/${{ github.ref_name }} \
-          ghcr.io/${{ github.repository_owner }}/data-platform-control-panel:${{ github.ref_name }}
+          ghcr.io/${{ github.repository_owner }}/data-platform-control-panel:${{ steps.push.outputs.digest }}


### PR DESCRIPTION
This pull request updates cosign to use the image's digest rather than it's tag

cosign is currently warning us with:

```
WARNING: Image reference ghcr.io/ministryofjustice/data-platform-control-panel:${GITHUB_REF} uses a tag, not a digest, to identify the image to sign.
    This can lead you to sign a different image than the intended one. Please use a
    digest (example.com/ubuntu@sha256:abc123...) rather than tag
    (example.com/ubuntu:latest) for the input to cosign. The ability to refer to
    images by tag will be removed in a future release.
```

[source](https://github.com/ministryofjustice/data-platform-control-panel/actions/runs/7035857666/job/19147203328#step:6:8)

